### PR TITLE
Shrink the amount of space for corrections

### DIFF
--- a/src/cabac_codec.rs
+++ b/src/cabac_codec.rs
@@ -276,10 +276,6 @@ impl<W: CabacWriter<CTX>, CTX: Default> PredictionEncoderCabac<W, CTX> {
 }
 
 impl<W: CabacWriter<CTX>, CTX> PredictionEncoder for PredictionEncoderCabac<W, CTX> {
-    fn encode_value(&mut self, value: u16, max_bits: u8) {
-        self.context.encode_value(value, max_bits, &mut self.writer);
-    }
-
     fn encode_verify_state(&mut self, _message: &'static str, _checksum: u64) {}
 
     fn encode_correction(&mut self, action: CodecCorrection, value: u32) {
@@ -315,9 +311,6 @@ impl<R: CabacReader<CTX>, CTX: Default> PredictionDecoderCabac<R, CTX> {
 }
 
 impl<R: CabacReader<CTX>, CTX> PredictionDecoder for PredictionDecoderCabac<R, CTX> {
-    fn decode_value(&mut self, max_bits_orig: u8) -> u16 {
-        self.context.decode_value(max_bits_orig, &mut self.reader)
-    }
     fn decode_verify_state(&mut self, _message: &'static str, _checksum: u64) {}
 
     fn decode_correction(&mut self, correction: CodecCorrection) -> u32 {
@@ -339,7 +332,6 @@ fn roundtree_cabac_decoding() {
     let mut buffer = Vec::new();
 
     let test_codec_actions = [
-        CodecAction::Value(200, 8),
         CodecAction::Correction(CodecCorrection::DistanceCountCorrection, 1),
         CodecAction::Correction(CodecCorrection::TokenCount, 100000),
         CodecAction::Correction(CodecCorrection::BlockTypeCorrection, 5),

--- a/src/cabac_codec.rs
+++ b/src/cabac_codec.rs
@@ -340,7 +340,7 @@ fn roundtree_cabac_decoding() {
 
     let test_codec_actions = [
         CodecAction::Value(200, 8),
-        CodecAction::Misprediction(CodecMisprediction::DistanceCountMisprediction, true),
+        CodecAction::Correction(CodecCorrection::DistanceCountCorrection, 1),
         CodecAction::Correction(CodecCorrection::TokenCount, 100000),
         CodecAction::Correction(CodecCorrection::BlockTypeCorrection, 5),
         CodecAction::Correction(CodecCorrection::DistAfterLenCorrection, 0),
@@ -373,7 +373,7 @@ fn roundtree_cabac_correction() {
 
     // generate a random set of operations
     let operations = [
-        Operation::Misprediction(false, CodecMisprediction::DistanceCountMisprediction),
+        Operation::Correction(5, CodecCorrection::DistanceCountCorrection),
         Operation::Value(10, 4),
         Operation::Value(10, 4),
         Operation::Correction(1, CodecCorrection::BlockTypeCorrection),
@@ -386,11 +386,11 @@ fn roundtree_cabac_correction() {
         Operation::Correction(0, CodecCorrection::DistOnlyCorrection),
         Operation::Correction(7, CodecCorrection::LDTypeCorrection),
         Operation::Correction(9, CodecCorrection::LenCorrection),
-        Operation::Misprediction(false, CodecMisprediction::DistanceCountMisprediction),
+        Operation::Misprediction(false, CodecMisprediction::LiteralPredictionWrong),
         Operation::Correction(100000, CodecCorrection::TokenCount),
         Operation::Misprediction(false, CodecMisprediction::IrregularLen258),
         Operation::Value(10, 4),
-        Operation::Misprediction(false, CodecMisprediction::DistanceCountMisprediction),
+        Operation::Misprediction(false, CodecMisprediction::ReferencePredictionWrong),
         //Operation::Misprediction(true, CodecMisprediction::DistanceCountMisprediction),
     ];
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -415,7 +415,7 @@ fn verify_longmatch() {
     do_analyze(
         None,
         &read_file("compressed_flate2_level1_longmatch.deflate"),
-        true,
+        false,
     );
 }
 

--- a/src/statistical_codec.rs
+++ b/src/statistical_codec.rs
@@ -77,6 +77,7 @@ pub enum CodecAction {
 #[derive(Default)]
 pub struct CountNonDefaultActions {
     pub total_non_default: u32,
+
     pub mispredictions_count: [u32; CodecMisprediction::MAX as usize],
     pub corrections_count: [u32; CodecCorrection::MAX as usize],
 }

--- a/src/statistical_codec.rs
+++ b/src/statistical_codec.rs
@@ -77,7 +77,6 @@ pub enum CodecAction {
 pub struct CountNonDefaultActions {
     pub total_non_default: u32,
 
-    pub mispredictions_count: [u32; CodecCorrection::MAX as usize],
     pub corrections_count: [u32; CodecCorrection::MAX as usize],
 }
 
@@ -85,13 +84,6 @@ impl CountNonDefaultActions {
     pub fn record_correction(&mut self, correction: CodecCorrection, value: u32) {
         if value != 0 {
             self.corrections_count[correction as usize] += 1;
-            self.total_non_default += 1;
-        }
-    }
-
-    pub fn record_misprediction(&mut self, misprediction: CodecCorrection, value: bool) {
-        if value {
-            self.mispredictions_count[misprediction as usize] += 1;
             self.total_non_default += 1;
         }
     }

--- a/src/statistical_codec.rs
+++ b/src/statistical_codec.rs
@@ -92,6 +92,8 @@ impl CountNonDefaultActions {
         use CodecCorrection::*;
 
         let corr = [
+            TokenCount,
+            NonZeroPadding,
             BlockTypeCorrection,
             LenCorrection,
             DistOnlyCorrection,
@@ -100,15 +102,21 @@ impl CountNonDefaultActions {
             LDTypeCorrection,
             RepeatCountCorrection,
             LDBitLengthCorrection,
-            NonZeroPadding,
             TreeCodeCountCorrection,
             LiteralCountCorrection,
             DistanceCountCorrection,
+            UncompressBlockLenCorrection,
             EOFMisprediction,
             LiteralPredictionWrong,
             ReferencePredictionWrong,
             IrregularLen258,
         ];
+
+        assert_eq!(
+            corr.len(),
+            CodecCorrection::MAX as usize,
+            "need to update array if you add an enum"
+        );
 
         for i in corr {
             if self.corrections_count[i as usize] != 0 {

--- a/src/token_predictor.rs
+++ b/src/token_predictor.rs
@@ -268,7 +268,10 @@ impl<'a> TokenPredictor<'a> {
                             .with_context(|| {
                                 format!("calculate_hops p={:?}, t={:?}", predicted_ref, target_ref)
                             })?;
-                        codec.encode_correction(CodecCorrection::DistAfterLenCorrection, rematch);
+                        codec.encode_correction(
+                            CodecCorrection::DistAfterLenCorrection,
+                            rematch - 1,
+                        );
                     } else if target_ref.dist() != predicted_ref.dist() {
                         let rematch = self
                             .state
@@ -405,7 +408,7 @@ impl<'a> TokenPredictor<'a> {
             );
 
             if new_len != predicted_ref.len() {
-                let hops = codec.decode_correction(CodecCorrection::DistAfterLenCorrection);
+                let hops = codec.decode_correction(CodecCorrection::DistAfterLenCorrection) + 1;
 
                 predicted_ref = DeflateTokenReference::new(
                     new_len,

--- a/src/token_predictor.rs
+++ b/src/token_predictor.rs
@@ -118,7 +118,11 @@ impl<'a> TokenPredictor<'a> {
                     BT_DYNAMICHUFF,
                 );
 
-                codec.encode_value(uncompressed.len() as u16, 16);
+                codec.encode_correction_diff(
+                    CodecCorrection::UncompressBlockLenCorrection,
+                    uncompressed.len() as u32,
+                    65535,
+                );
 
                 codec.encode_correction(CodecCorrection::NonZeroPadding, (*padding_bits).into());
 
@@ -322,7 +326,8 @@ impl<'a> TokenPredictor<'a> {
 
         match bt {
             BT_STORED => {
-                let uncompressed_len = codec.decode_value(16).into();
+                let uncompressed_len = codec
+                    .decode_correction_diff(CodecCorrection::UncompressBlockLenCorrection, 65535);
                 let padding_bits = codec.decode_correction(CodecCorrection::NonZeroPadding) as u8;
                 let mut uncompressed = Vec::with_capacity(uncompressed_len as usize);
 

--- a/src/tree_predictor.rs
+++ b/src/tree_predictor.rs
@@ -147,9 +147,9 @@ pub fn recreate_tree_for_block<D: PredictionDecoder>(
     tc_code_tree.resize(CODETREE_CODE_COUNT, 0);
 
     for i in 0..tc_code_tree_len {
-        result.code_lengths[TREE_CODE_ORDER_TABLE[i]] = decode_difference(
+        result.code_lengths[TREE_CODE_ORDER_TABLE[i]] = codec.decode_correction_diff(
+            CodecCorrection::TreeCodeBitLengthCorrection,
             tc_code_tree[TREE_CODE_ORDER_TABLE[i]].into(),
-            codec.decode_correction(CodecCorrection::TreeCodeBitLengthCorrection),
         ) as u8;
     }
 

--- a/src/tree_predictor.rs
+++ b/src/tree_predictor.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     cabac_codec::{decode_difference, encode_difference},
-    deflate::deflate_constants::{CODETREE_CODE_COUNT, NONLEN_CODE_COUNT, TREE_CODE_ORDER_TABLE},
+    deflate::deflate_constants::{CODETREE_CODE_COUNT, TREE_CODE_ORDER_TABLE},
     deflate::deflate_token::TokenFrequency,
     deflate::{
         huffman_calc::{calc_bit_lengths, HufftreeBitCalc},

--- a/src/tree_predictor.rs
+++ b/src/tree_predictor.rs
@@ -13,9 +13,7 @@ use crate::{
         huffman_encoding::{HuffmanOriginalEncoding, TreeCodeType},
     },
     preflate_error::{err_exit_code, ExitCode, Result},
-    statistical_codec::{
-        CodecCorrection, CodecMisprediction, PredictionDecoder, PredictionEncoder,
-    },
+    statistical_codec::{CodecCorrection, PredictionDecoder, PredictionEncoder},
 };
 
 pub fn predict_tree_for_block<D: PredictionEncoder>(


### PR DESCRIPTION
Change the way we track corrections so that each distance between non-default values is tracked separately.