### PR TITLE
Move complexity of fixed size buffers out of the container code

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "cargo",
+			"command": "build",
+			"problemMatcher": [
+				"$rustc"
+			],
+			"args": [
+				 "--workspace",
+			],
+			"group": "build",
+			"label": "rust: cargo build"
+		}
+	]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "preflate-container"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "adler32",
  "byteorder",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "preflate_rs_0_7"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "preflate-container",
  "preflate-rs",

--- a/container/Cargo.toml
+++ b/container/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "preflate-container"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 authors = ["Kristof Roomp <kristofr@microsoft.com>"]
 license = "Apache-2.0"

--- a/container/src/container_processor.rs
+++ b/container/src/container_processor.rs
@@ -11,7 +11,7 @@ use crate::{
     idat_parse::{IdatContents, PngHeader, recreate_idat},
     scan_deflate::{FindStreamResult, FoundStream, FoundStreamType, find_compressable_stream},
     scoped_read::ScopedRead,
-    utils::{TakeReader, write_dequeue},
+    utils::TakeReader,
 };
 
 use preflate_rs::{
@@ -252,7 +252,7 @@ fn read_chunk_block_slow(
     destination: &mut impl Write,
 ) -> std::result::Result<(), PreflateError> {
     let mut p = RecreateContainerProcessor::new_single_chunk(usize::MAX);
-    p.copy_to_end_size(source, destination, 1, 1).context()
+    p.copy_to_end_size(source, destination, 1).context()
 }
 
 #[test]
@@ -418,7 +418,6 @@ pub trait ProcessBuffer {
         input: &[u8],
         input_complete: bool,
         writer: &mut impl Write,
-        max_output_write: usize,
     ) -> Result<bool>;
 
     #[cfg(test)]
@@ -432,19 +431,13 @@ pub trait ProcessBuffer {
     }
 
     #[cfg(test)]
-    fn process_vec_size(
-        &mut self,
-        input: &[u8],
-        read_chunk_size: usize,
-        write_chunk_size: usize,
-    ) -> Result<Vec<u8>> {
+    fn process_vec_size(&mut self, input: &[u8], read_chunk_size: usize) -> Result<Vec<u8>> {
         let mut writer = Vec::new();
 
         self.copy_to_end_size(
             &mut std::io::Cursor::new(&input),
             &mut writer,
             read_chunk_size,
-            write_chunk_size,
         )
         .context()?;
 
@@ -454,7 +447,7 @@ pub trait ProcessBuffer {
     /// Reads everything from input and writes it to the output.
     /// Wraps calls to process buffer
     fn copy_to_end(&mut self, input: &mut impl BufRead, output: &mut impl Write) -> Result<()> {
-        self.copy_to_end_size(input, output, 1024 * 1024, 1024 * 1024)
+        self.copy_to_end_size(input, output, 1024 * 1024)
     }
 
     /// Reads everything from input and writes it to the output.
@@ -464,7 +457,6 @@ pub trait ProcessBuffer {
         input: &mut impl BufRead,
         output: &mut impl Write,
         read_chunk_size: usize,
-        write_chunk_size: usize,
     ) -> Result<()> {
         let mut input_complete = false;
         loop {
@@ -479,10 +471,7 @@ pub trait ProcessBuffer {
             };
 
             if input_complete {
-                if self
-                    .process_buffer(&[], true, output, usize::MAX)
-                    .context()?
-                {
+                if self.process_buffer(&[], true, output).context()? {
                     break;
                 }
             } else {
@@ -497,7 +486,6 @@ pub trait ProcessBuffer {
                                 &buffer[amount_read..amount_read + chunk_size],
                                 false,
                                 output,
-                                write_chunk_size,
                             )
                             .context()?,
                         "process_buffer should not return done until input is done"
@@ -539,7 +527,6 @@ enum ChunkParseState {
 /// deflate stream directlyh.
 pub struct PreflateContainerProcessor {
     content: Vec<u8>,
-    result: VecDeque<u8>,
     compression_stats: PreflateStats,
     input_complete: bool,
     total_plain_text_seen: u64,
@@ -558,7 +545,6 @@ impl PreflateContainerProcessor {
         PreflateContainerProcessor {
             content: Vec::new(),
             compression_stats: PreflateStats::default(),
-            result: VecDeque::new(),
             input_complete: false,
             state: ChunkParseState::Start,
             total_plain_text_seen: 0,
@@ -574,7 +560,6 @@ impl ProcessBuffer for PreflateContainerProcessor {
         input: &[u8],
         input_complete: bool,
         writer: &mut impl Write,
-        max_output_write: usize,
     ) -> Result<bool> {
         if self.input_complete && (input.len() > 0 || !input_complete) {
             return Err(PreflateError::new(
@@ -603,7 +588,7 @@ impl ProcessBuffer for PreflateContainerProcessor {
 
             match &mut self.state {
                 ChunkParseState::Start => {
-                    self.result.write_all(&[COMPRESSED_WRAPPER_VERSION_1])?;
+                    writer.write_all(&[COMPRESSED_WRAPPER_VERSION_1])?;
                     self.state = ChunkParseState::Searching(None);
                 }
                 ChunkParseState::Searching(prev_ihdr) => {
@@ -611,7 +596,7 @@ impl ProcessBuffer for PreflateContainerProcessor {
                         // once we've exceeded our limit, we don't do any more compression
                         // this is to ensure we don't suck the CPU time for too long on
                         // a single file
-                        write_literal_block(&self.content, &mut self.result)?;
+                        write_literal_block(&self.content, writer)?;
 
                         self.last_attempt_chunk_size = 0;
                         self.content.clear();
@@ -629,15 +614,12 @@ impl ProcessBuffer for PreflateContainerProcessor {
                             // the gap between the start and the beginning of the deflate stream
                             // is written out as a literal block
                             if next.start != 0 {
-                                write_literal_block(&self.content[..next.start], &mut self.result)?;
+                                write_literal_block(&self.content[..next.start], writer)?;
                             }
 
-                            if let Some(mut state) = write_chunk_block(
-                                &mut self.result,
-                                chunk,
-                                &mut self.compression_stats,
-                            )
-                            .context()?
+                            if let Some(mut state) =
+                                write_chunk_block(writer, chunk, &mut self.compression_stats)
+                                    .context()?
                             {
                                 self.total_plain_text_seen += state.plain_text().len() as u64;
                                 state.shrink_to_dictionary();
@@ -652,7 +634,7 @@ impl ProcessBuffer for PreflateContainerProcessor {
                             if input_complete || self.content.len() > self.config.max_chunk_size {
                                 // if we have too much data or have no more data,
                                 // we just write it out as a literal block with everything we have
-                                write_literal_block(&self.content, &mut self.result)?;
+                                write_literal_block(&self.content, writer)?;
 
                                 self.content.clear();
                                 self.last_attempt_chunk_size = 0;
@@ -664,7 +646,7 @@ impl ProcessBuffer for PreflateContainerProcessor {
                         }
                         FindStreamResult::None => {
                             // couldn't find anything, just write the rest as a literal block
-                            write_literal_block(&self.content, &mut self.result)?;
+                            write_literal_block(&self.content, writer)?;
 
                             self.content.clear();
                             self.last_attempt_chunk_size = 0;
@@ -691,13 +673,13 @@ impl ProcessBuffer for PreflateContainerProcessor {
                                 res.compressed_size
                             );
 
-                            self.result.write_all(&[DEFLATE_STREAM_CONTINUE])?;
+                            writer.write_all(&[DEFLATE_STREAM_CONTINUE])?;
 
-                            write_varint(&mut self.result, res.corrections.len() as u32)?;
-                            write_varint(&mut self.result, state.plain_text().len() as u32)?;
+                            write_varint(writer, res.corrections.len() as u32)?;
+                            write_varint(writer, state.plain_text().len() as u32)?;
 
-                            self.result.write_all(&res.corrections)?;
-                            self.result.write_all(&state.plain_text().text())?;
+                            writer.write_all(&res.corrections)?;
+                            writer.write_all(&state.plain_text().text())?;
 
                             self.total_plain_text_seen += state.plain_text().len() as u64;
                             self.compression_stats.overhead_bytes += res.corrections.len() as u64;
@@ -722,15 +704,12 @@ impl ProcessBuffer for PreflateContainerProcessor {
             self.input_complete = true;
 
             if self.content.len() > 0 {
-                write_literal_block(&self.content, &mut self.result)?;
+                write_literal_block(&self.content, writer)?;
             }
             self.content.clear();
         }
 
-        // write any output we have pending in the queue into the output buffer
-        write_dequeue(&mut self.result, writer, max_output_write).context()?;
-
-        Ok(self.input_complete && self.result.len() == 0)
+        Ok(self.input_complete)
     }
 
     fn stats(&self) -> PreflateStats {
@@ -739,18 +718,7 @@ impl ProcessBuffer for PreflateContainerProcessor {
 }
 
 #[cfg(test)]
-pub struct NopProcessBuffer {
-    result: VecDeque<u8>,
-}
-
-#[cfg(test)]
-impl NopProcessBuffer {
-    pub fn new() -> Self {
-        NopProcessBuffer {
-            result: VecDeque::new(),
-        }
-    }
-}
+pub struct NopProcessBuffer {}
 
 #[cfg(test)]
 impl ProcessBuffer for NopProcessBuffer {
@@ -759,13 +727,10 @@ impl ProcessBuffer for NopProcessBuffer {
         input: &[u8],
         input_complete: bool,
         writer: &mut impl Write,
-        max_output_write: usize,
     ) -> Result<bool> {
-        self.result.extend(input);
+        writer.write_all(input).context()?;
 
-        write_dequeue(&mut self.result, writer, max_output_write).context()?;
-
-        Ok(input_complete && self.result.len() == 0)
+        Ok(input_complete)
     }
 }
 
@@ -789,7 +754,6 @@ enum DecompressionState {
 pub struct RecreateContainerProcessor {
     capacity: usize,
     input: VecDeque<u8>,
-    result: VecDeque<u8>,
     input_complete: bool,
     state: DecompressionState,
 
@@ -802,7 +766,6 @@ impl RecreateContainerProcessor {
     pub fn new(capacity: usize) -> Self {
         RecreateContainerProcessor {
             input: VecDeque::new(),
-            result: VecDeque::new(),
             capacity,
             input_complete: false,
             state: DecompressionState::Start,
@@ -814,7 +777,6 @@ impl RecreateContainerProcessor {
     pub fn new_single_chunk(capacity: usize) -> Self {
         RecreateContainerProcessor {
             input: VecDeque::new(),
-            result: VecDeque::new(),
             capacity,
             input_complete: false,
             state: DecompressionState::StartSegment,
@@ -829,7 +791,6 @@ impl ProcessBuffer for RecreateContainerProcessor {
         input: &[u8],
         input_complete: bool,
         writer: &mut impl Write,
-        mut max_output_write: usize,
     ) -> Result<bool> {
         if self.input_complete && (input.len() > 0 || !input_complete) {
             return Err(PreflateError::new(
@@ -853,22 +814,19 @@ impl ProcessBuffer for RecreateContainerProcessor {
 
             amount_read += amount_to_read;
 
-            self.process_buffer_internal()?;
-            let amount_written =
-                write_dequeue(&mut self.result, writer, max_output_write).context()?;
+            self.process_buffer_internal(writer)?;
 
-            max_output_write -= amount_written;
             if amount_read == input.len() {
                 break;
             }
         }
 
-        Ok(self.input_complete && self.result.len() == 0)
+        Ok(self.input_complete)
     }
 }
 
 impl RecreateContainerProcessor {
-    fn process_buffer_internal(&mut self) -> Result<()> {
+    fn process_buffer_internal(&mut self, writer: &mut impl Write) -> Result<()> {
         loop {
             match &mut self.state {
                 DecompressionState::Start => {
@@ -978,12 +936,13 @@ impl RecreateContainerProcessor {
                                 "unexpected end of input",
                             ));
                         }
-                        self.result.extend(self.input.drain(..));
+
+                        std::io::copy(&mut self.input, writer).context()?;
                         *length -= source_size;
                         break;
                     }
 
-                    self.result.extend(self.input.drain(0..*length));
+                    std::io::copy(&mut (&mut self.input).take(*length as u64), writer).context()?;
                     self.state = DecompressionState::StartSegment;
                 }
 
@@ -1011,7 +970,7 @@ impl RecreateContainerProcessor {
                             )
                             .context()?;
 
-                        self.result.extend(&comp);
+                        writer.write_all(&comp)?;
                     } else {
                         let mut reconstruct = RecreateStreamProcessor::new();
                         let (comp, _) = reconstruct
@@ -1021,7 +980,7 @@ impl RecreateContainerProcessor {
                             )
                             .context()?;
 
-                        self.result.extend(&comp);
+                        writer.write_all(&comp)?;
 
                         self.deflate_continue_state = Some(reconstruct);
                     }
@@ -1064,7 +1023,7 @@ impl RecreateContainerProcessor {
                     let recompressed =
                         recreate_whole_deflate_stream(&plain_text, &corrections).context()?;
 
-                    recreate_idat(&idat, &recompressed[..], &mut self.result).context()?;
+                    recreate_idat(&idat, &recompressed[..], writer).context()?;
 
                     self.state = DecompressionState::StartSegment;
                 }
@@ -1084,7 +1043,7 @@ impl RecreateContainerProcessor {
 
                     match lepton_jpeg::decode_lepton(
                         &mut Cursor::new(&lepton_data),
-                        &mut self.result,
+                        writer,
                         &EnabledFeatures::compat_lepton_vector_read(),
                         &DEFAULT_THREAD_POOL,
                     ) {
@@ -1259,10 +1218,10 @@ fn roundtrip_small_chunk() {
         ..Default::default()
     });
 
-    let compressed = context.process_vec_size(&original, 20001, 997).unwrap();
+    let compressed = context.process_vec_size(&original, 20001).unwrap();
 
     let mut context = RecreateContainerProcessor::new(usize::MAX);
-    let recreated = context.process_vec_size(&compressed, 20001, 997).unwrap();
+    let recreated = context.process_vec_size(&compressed, 20001).unwrap();
 
     assert_eq_array(&original, &recreated);
 }
@@ -1280,10 +1239,10 @@ fn roundtrip_small_plain_text() {
         ..Default::default()
     });
 
-    let compressed = context.process_vec_size(&original, 2001, 20001).unwrap();
+    let compressed = context.process_vec_size(&original, 2001).unwrap();
 
     let mut context = RecreateContainerProcessor::new(usize::MAX);
-    let recreated = context.process_vec_size(&compressed, 2001, 20001).unwrap();
+    let recreated = context.process_vec_size(&compressed, 2001).unwrap();
 
     assert_eq_array(&original, &recreated);
 }
@@ -1304,14 +1263,12 @@ fn roundtrip_png_e2e() {
         ..Default::default()
     });
 
-    let compressed = context.process_vec_size(&original, 100100, 100100).unwrap();
+    let compressed = context.process_vec_size(&original, 100100).unwrap();
 
     println!("Recreating file");
 
     let mut context = RecreateContainerProcessor::new(usize::MAX);
-    let recreated = context
-        .process_vec_size(&compressed, 100100, 100100)
-        .unwrap();
+    let recreated = context.process_vec_size(&compressed, 100100).unwrap();
 
     assert_eq_array(&original, &recreated);
 }
@@ -1332,9 +1289,7 @@ fn roundtrip_jpg() {
         ..Default::default()
     });
 
-    let compressed = context
-        .process_vec_size(&original, usize::MAX, usize::MAX)
-        .unwrap();
+    let compressed = context.process_vec_size(&original, usize::MAX).unwrap();
 
     println!(
         "Compressed size: {} vs {}",
@@ -1345,9 +1300,7 @@ fn roundtrip_jpg() {
     println!("Recreating file");
 
     let mut context = RecreateContainerProcessor::new(usize::MAX);
-    let recreated = context
-        .process_vec_size(&compressed, usize::MAX, usize::MAX)
-        .unwrap();
+    let recreated = context.process_vec_size(&compressed, usize::MAX).unwrap();
 
     assert_eq_array(&original, &recreated);
 }

--- a/container/src/lib.rs
+++ b/container/src/lib.rs
@@ -38,6 +38,8 @@ pub use container_processor::{
 
 pub use zstd_compression::{ZstdCompressContext, ZstdDecompressContext};
 
+pub use utils::process_limited_buffer;
+
 #[cfg(test)]
 static INIT: std::sync::Once = std::sync::Once::new();
 

--- a/container/src/utils.rs
+++ b/container/src/utils.rs
@@ -1,26 +1,4 @@
-use std::{
-    collections::VecDeque,
-    io::{BufRead, Read, Write},
-};
-
-use preflate_rs::Result;
-
-/// writes the pending output to the writer
-pub fn write_dequeue(pending_output: &mut VecDeque<u8>, writer: &mut impl Write) -> Result<usize> {
-    if pending_output.len() > 0 {
-        let slices = pending_output.as_mut_slices();
-
-        writer.write_all(slices.0)?;
-        writer.write_all(slices.1)?;
-
-        let amount_written = slices.0.len() + slices.1.len();
-        pending_output.drain(..);
-
-        Ok(amount_written)
-    } else {
-        Ok(0)
-    }
-}
+use std::io::{BufRead, Read};
 
 /// A BufRead implementation that reads at most `limit` bytes from the underlying reader.
 pub struct TakeReader<T> {

--- a/container/src/utils.rs
+++ b/container/src/utils.rs
@@ -144,6 +144,8 @@ impl Write for LimitedOutputWriter<'_> {
 ///
 /// This avoids adding complexity to every ProcessBuffer implementation to handle the case where there is too
 /// much output to fit in the output buffer.
+///
+/// Returns a tuple (complete, amount_written) where complete is true if all output was written.
 pub fn process_limited_buffer(
     process: &mut impl ProcessBuffer,
     input: &[u8],
@@ -167,7 +169,7 @@ pub fn process_limited_buffer(
     };
     process.process_buffer(input, input_complete, &mut w)?;
 
-    Ok((w.extra_queue.len() == 0, w.amount_written))
+    Ok((input_complete && w.extra_queue.len() == 0, w.amount_written))
 }
 
 #[test]

--- a/container/src/utils.rs
+++ b/container/src/utils.rs
@@ -6,26 +6,16 @@ use std::{
 use preflate_rs::Result;
 
 /// writes the pending output to the writer
-pub fn write_dequeue(
-    pending_output: &mut VecDeque<u8>,
-    writer: &mut impl Write,
-    max_output_write: usize,
-) -> Result<usize> {
+pub fn write_dequeue(pending_output: &mut VecDeque<u8>, writer: &mut impl Write) -> Result<usize> {
     if pending_output.len() > 0 {
         let slices = pending_output.as_mut_slices();
 
-        let mut amount_written = 0;
-        let len = slices.0.len().min(max_output_write);
-        writer.write_all(&slices.0[..len])?;
-        amount_written += len;
+        writer.write_all(slices.0)?;
+        writer.write_all(slices.1)?;
 
-        if amount_written < max_output_write {
-            let len = slices.1.len().min(max_output_write - amount_written);
-            writer.write_all(&slices.1[..len])?;
-            amount_written += len;
-        }
+        let amount_written = slices.0.len() + slices.1.len();
+        pending_output.drain(..);
 
-        pending_output.drain(..amount_written);
         Ok(amount_written)
     } else {
         Ok(0)

--- a/container/src/utils.rs
+++ b/container/src/utils.rs
@@ -1,4 +1,11 @@
-use std::io::{BufRead, Read};
+use std::{
+    collections::VecDeque,
+    io::{BufRead, Read, Write},
+};
+
+use preflate_rs::Result;
+
+use crate::ProcessBuffer;
 
 /// A BufRead implementation that reads at most `limit` bytes from the underlying reader.
 pub struct TakeReader<T> {
@@ -100,4 +107,114 @@ pub fn assert_eq_array<T: PartialEq + std::fmt::Debug>(a: &[T], b: &[T]) {
             );
         }
     }
+}
+
+struct LimitedOutputWriter<'a> {
+    amount_written: usize,
+    output_buffer: &'a mut [u8],
+    extra_queue: &'a mut VecDeque<u8>,
+}
+
+impl Write for LimitedOutputWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let amount_for_output = buf
+            .len()
+            .min(self.output_buffer.len() - self.amount_written);
+
+        self.output_buffer[self.amount_written..self.amount_written + amount_for_output]
+            .copy_from_slice(&buf[..amount_for_output]);
+        self.amount_written += amount_for_output;
+
+        if amount_for_output < buf.len() {
+            self.extra_queue.extend(&buf[amount_for_output..]);
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        // nothing to do since we don't buffer anything
+        Ok(())
+    }
+}
+
+/// Processes input data, writing output to the output buffer and any extra to the output_extra queue.
+///
+/// This is necessary because in the unmanaged wrapper we cannot expand the buffer that was given to us,
+/// so we have to write as much as we can to the output buffer and then queue up any extra data for next time.
+///
+/// This avoids adding complexity to every ProcessBuffer implementation to handle the case where there is too
+/// much output to fit in the output buffer.
+pub fn process_limited_buffer(
+    process: &mut impl ProcessBuffer,
+    input: &[u8],
+    input_complete: bool,
+    output_buffer: &mut [u8],
+    output_extra: &mut VecDeque<u8>,
+) -> Result<(bool, usize)> {
+    // first write any extra data we have pending from last time
+    let mut amount_written = 0;
+    while amount_written < output_buffer.len() && output_extra.len() > 0 {
+        amount_written += output_extra
+            .read(&mut output_buffer[amount_written..])
+            .unwrap();
+    }
+
+    // now call process buffer with the remaining space
+    let mut w = LimitedOutputWriter {
+        amount_written,
+        output_buffer,
+        extra_queue: output_extra,
+    };
+    process.process_buffer(input, input_complete, &mut w)?;
+
+    Ok((w.extra_queue.len() == 0, w.amount_written))
+}
+
+#[test]
+fn test_process_limited_buffer() {
+    let mut p = crate::container_processor::NopProcessBuffer {};
+
+    let input = b"Hello, world!";
+    let mut output = [0u8; 5];
+    let mut extra = VecDeque::new();
+
+    // first call should write "Hello" and queue up the rest
+    let (complete, written) =
+        process_limited_buffer(&mut p, input, true, &mut output, &mut extra).unwrap();
+    assert!(!complete);
+    assert_eq!(written, 5);
+    assert_eq!(&output, b"Hello");
+    assert_eq!(extra.len(), 8); // ", world!"
+
+    // second call with no input should write the queued data
+    let (complete, written) =
+        process_limited_buffer(&mut p, &[], true, &mut output, &mut extra).unwrap();
+    assert!(!complete);
+    assert_eq!(written, 5);
+    assert_eq!(&output, b", wor");
+    assert_eq!(extra.len(), 3); // "ld!"
+
+    // third call with no input should write the remaining queued data
+    let (complete, written) =
+        process_limited_buffer(&mut p, &[], true, &mut output, &mut extra).unwrap();
+    assert!(complete);
+    assert_eq!(written, 3);
+    assert_eq!(&output[..3], b"ld!");
+    assert_eq!(extra.len(), 0);
+
+    // fourth call with no input should do nothing
+    let (complete, written) =
+        process_limited_buffer(&mut p, &[], true, &mut output, &mut extra).unwrap();
+    assert!(complete);
+    assert_eq!(written, 0);
+    assert_eq!(extra.len(), 0);
+
+    // now test with input that fits in the buffer
+    let input = b"Hi!";
+    let (complete, written) =
+        process_limited_buffer(&mut p, input, true, &mut output, &mut extra).unwrap();
+    assert!(complete);
+    assert_eq!(written, 3);
+    assert_eq!(&output[..3], b"Hi!");
+    assert_eq!(extra.len(), 0);
 }

--- a/container/src/zstd_compression.rs
+++ b/container/src/zstd_compression.rs
@@ -3,14 +3,11 @@
 //! the other ProcessBuffer implementations to create a full compression or
 //! decompression pipeline.
 
-use std::{
-    collections::VecDeque,
-    io::{BufRead, Write},
-};
+use std::io::{BufRead, Write};
 
 use crate::{
     PreflateContainerProcessor, PreflateStats, ProcessBuffer, RecreateContainerProcessor,
-    container_processor::PreflateContainerConfig, utils::write_dequeue,
+    container_processor::PreflateContainerConfig,
 };
 
 use preflate_rs::{AddContext, ExitCode, PreflateError, Result};
@@ -19,7 +16,7 @@ use preflate_rs::{AddContext, ExitCode, PreflateError, Result};
 ///
 /// Designed to wrap around the PreflateChunkProcessor.
 pub struct ZstdCompressContext<D: ProcessBuffer> {
-    zstd_compress: zstd::stream::write::Encoder<'static, VecDeque<u8>>,
+    zstd_compress: zstd::stream::write::Encoder<'static, Vec<u8>>,
     input_complete: bool,
     internal: D,
 
@@ -33,17 +30,14 @@ pub struct ZstdCompressContext<D: ProcessBuffer> {
 
     zstd_baseline_size: u64,
     zstd_compressed_size: u64,
-
-    done_write: bool,
 }
 
 impl<D: ProcessBuffer> ZstdCompressContext<D> {
     pub fn new(internal: D, compression_level: i32, test_baseline: bool) -> Self {
         ZstdCompressContext {
-            zstd_compress: zstd::stream::write::Encoder::new(VecDeque::new(), compression_level)
+            zstd_compress: zstd::stream::write::Encoder::new(Vec::new(), compression_level)
                 .unwrap(),
             input_complete: false,
-            done_write: false,
             internal,
             zstd_baseline_size: 0,
             zstd_compressed_size: 0,
@@ -68,7 +62,7 @@ impl<D: ProcessBuffer> ProcessBuffer for ZstdCompressContext<D> {
         input: &[u8],
         input_complete: bool,
         writer: &mut impl Write,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         if self.input_complete && (input.len() > 0 || !input_complete) {
             return Err(PreflateError::new(
                 ExitCode::InvalidParameter,
@@ -82,22 +76,13 @@ impl<D: ProcessBuffer> ProcessBuffer for ZstdCompressContext<D> {
             }
         }
 
-        if input_complete && !self.input_complete {
-            self.input_complete = true;
-        }
-
-        let done_write = self
-            .internal
+        self.internal
             .process_buffer(input, input_complete, &mut self.zstd_compress)
             .context()?;
 
-        if done_write && !self.done_write {
-            debug_assert!(
-                input_complete,
-                "can't be done writing if the input is not complete"
-            );
+        if input_complete && !self.input_complete {
+            self.input_complete = true;
 
-            self.done_write = true;
             self.zstd_compress.flush().context()?;
 
             if let Some(encoder) = &mut self.test_baseline {
@@ -107,11 +92,12 @@ impl<D: ProcessBuffer> ProcessBuffer for ZstdCompressContext<D> {
             }
         }
 
-        let output = self.zstd_compress.get_mut();
-        let amount_written = write_dequeue(output, writer).context()?;
-        self.zstd_compressed_size += amount_written as u64;
+        let compressed = self.zstd_compress.get_mut();
+        writer.write_all(compressed).context()?;
+        self.zstd_compressed_size += compressed.len() as u64;
+        compressed.drain(..);
 
-        Ok(done_write && output.len() == 0)
+        Ok(())
     }
 
     fn stats(&self) -> PreflateStats {
@@ -143,7 +129,7 @@ impl Write for MeasureWriteSink {
 ///
 /// Designed to wrap around the RecreateContainerProcessor.
 pub struct ZstdDecompressContext<D: ProcessBuffer> {
-    zstd_decompress: zstd::stream::write::Decoder<'static, AcceptWrite<D, VecDeque<u8>>>,
+    zstd_decompress: zstd::stream::write::Decoder<'static, AcceptWrite<D, Vec<u8>>>,
 }
 
 /// used to accept the output from the Zstandard decoder and write it to the output buffer.
@@ -153,14 +139,12 @@ struct AcceptWrite<D: ProcessBuffer, O: Write> {
     internal: D,
     output: O,
     input_complete: bool,
-    output_complete: bool,
 }
 
 impl<P: ProcessBuffer, O: Write> Write for AcceptWrite<P, O> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.output_complete =
-            self.internal
-                .process_buffer(buf, self.input_complete, &mut self.output)?;
+        self.internal
+            .process_buffer(buf, self.input_complete, &mut self.output)?;
         Ok(buf.len())
     }
 
@@ -174,9 +158,8 @@ impl<D: ProcessBuffer> ZstdDecompressContext<D> {
         ZstdDecompressContext {
             zstd_decompress: zstd::stream::write::Decoder::new(AcceptWrite {
                 internal: internal,
-                output: VecDeque::new(),
+                output: Vec::new(),
                 input_complete: false,
-                output_complete: false,
             })
             .unwrap(),
         }
@@ -189,7 +172,7 @@ impl<D: ProcessBuffer> ProcessBuffer for ZstdDecompressContext<D> {
         input: &[u8],
         input_complete: bool,
         writer: &mut impl Write,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         if self.zstd_decompress.get_mut().input_complete && (input.len() > 0 || !input_complete) {
             return Err(PreflateError::new(
                 ExitCode::InvalidParameter,
@@ -203,19 +186,14 @@ impl<D: ProcessBuffer> ProcessBuffer for ZstdDecompressContext<D> {
 
         if input_complete && !self.zstd_decompress.get_mut().input_complete {
             self.zstd_decompress.flush().context()?;
-
             self.zstd_decompress.get_mut().input_complete = true;
         }
 
         let a = self.zstd_decompress.get_mut();
+        writer.write_all(&a.output).context()?;
+        a.output.clear();
 
-        write_dequeue(&mut a.output, writer).context()?;
-
-        if input_complete && !a.output_complete && a.output.len() == 0 {
-            a.output_complete = a.internal.process_buffer(&[], true, writer)?;
-        }
-
-        Ok(a.output_complete && a.output.len() == 0)
+        Ok(())
     }
 }
 

--- a/dll/Cargo.toml
+++ b/dll/Cargo.toml
@@ -3,7 +3,7 @@
 # this makes sure that we can keep old versions around to decode old encodings since the format
 # is complicated enough that maintaining backwards compat is hard (even minor changes in the
 # predictor will break the format)
-version = "0.7.3"
+version = "0.7.4"
 name = "preflate_rs_0_7"
 edition = "2024"
 authors = ["Kristof Roomp <kristofr@microsoft.com>"]

--- a/dll/src/unmanaged_api.rs
+++ b/dll/src/unmanaged_api.rs
@@ -322,9 +322,9 @@ fn process_limited_buffer(
         output_buffer,
         extra_queue: output_extra,
     };
-    let done = process.process_buffer(input, input_complete, &mut w)?;
+    process.process_buffer(input, input_complete, &mut w)?;
 
-    Ok((done && w.extra_queue.len() == 0, w.amount_written))
+    Ok((w.extra_queue.len() == 0, w.amount_written))
 }
 
 /// Allocates new decompression context, must be freed with free_decompression_context

--- a/dll/src/unmanaged_api.rs
+++ b/dll/src/unmanaged_api.rs
@@ -1,5 +1,6 @@
 use std::{
-    io::Cursor,
+    collections::VecDeque,
+    io::{Read, Write},
     panic::{AssertUnwindSafe, catch_unwind},
     ptr::{null, null_mut},
 };
@@ -83,18 +84,12 @@ pub unsafe extern "C" fn create_compression_context(flags: u32) -> *mut std::ffi
         let test_baseline = (flags & 0x10) != 0;
         let verify = (flags & 0x20) != 0;
 
-        let context = Box::new((
-            12345678u32,
-            CompressionContext::new(
-                PreflateContainerProcessor::new(&PreflateContainerConfig {
-                    validate_compression: verify,
-                    max_chain_length: 1024, // lower max chain to avoid excessive CPU usage
-                    ..PreflateContainerConfig::default()
-                }),
-                compression_level,
-                test_baseline,
-            ),
+        let context = Box::new(CompressionContext::new(
+            verify,
+            compression_level,
+            test_baseline,
         ));
+
         Ok(Box::into_raw(context) as *mut std::ffi::c_void)
     }) {
         Ok(context) => context,
@@ -109,8 +104,11 @@ pub unsafe extern "C" fn create_compression_context(flags: u32) -> *mut std::ffi
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn free_compression_context(context: *mut std::ffi::c_void) {
     unsafe {
-        let x = Box::from_raw(context as *mut (u32, CompressionContext));
-        assert_eq!(x.0, 12345678, "invalid context passed in");
+        let x = Box::from_raw(context as *mut CompressionContext);
+        assert_eq!(
+            x.magic, MAGIC_COMPRESSION_CONTEXT,
+            "invalid context passed in"
+        );
         // let Box destroy the object. If this asserts, we have some kind of memory corruption so better to just kill the process.
     }
 }
@@ -133,9 +131,7 @@ pub unsafe extern "C" fn compress_buffer(
 ) -> i32 {
     unsafe {
         match catch_unwind_result(|| {
-            let context = context as *mut (u32, CompressionContext);
-            let (magic, context) = &mut *context;
-            assert_eq!(*magic, 12345678, "invalid context passed in");
+            let context = CompressionContext::from_pointer(context);
 
             let input = if input_buffer == null() {
                 &[]
@@ -148,15 +144,15 @@ pub unsafe extern "C" fn compress_buffer(
                 std::slice::from_raw_parts_mut(output_buffer, output_buffer_size as usize)
             };
 
-            let mut writer = Cursor::new(output);
-            let done = context.process_buffer(
+            let (done, buffer_written) = process_limited_buffer(
+                &mut context.internal,
                 input,
                 input_complete,
-                &mut writer,
-                output_buffer_size as usize,
+                output,
+                &mut context.output_extra,
             )?;
 
-            *result_size = writer.position().into();
+            *result_size = buffer_written as u64;
             Ok(done)
         }) {
             Ok(done) => done as i32,
@@ -188,11 +184,9 @@ pub unsafe extern "C" fn get_compression_stats(
     hash_algorithm: *mut u32,
 ) {
     unsafe {
-        let context = context as *mut (u32, CompressionContext);
-        let (magic, context) = &*context;
-        assert_eq!(*magic, 12345678, "invalid context passed in");
+        let context = CompressionContext::from_pointer(context);
 
-        let stats = context.stats();
+        let stats = context.internal.stats();
 
         *deflate_compressed_size = stats.deflate_compressed_size;
         *zstd_compressed_size = stats.zstd_compressed_size;
@@ -203,8 +197,135 @@ pub unsafe extern "C" fn get_compression_stats(
     }
 }
 
-type DecompressionContext = ZstdDecompressContext<RecreateContainerProcessor>;
-type CompressionContext = ZstdCompressContext<PreflateContainerProcessor>;
+struct CompressionContext {
+    magic: u32,
+    internal: ZstdCompressContext<PreflateContainerProcessor>,
+    output_extra: VecDeque<u8>,
+}
+
+struct LimitedOutputWriter<'a> {
+    amount_written: usize,
+    output_buffer: &'a mut [u8],
+    extra_queue: &'a mut VecDeque<u8>,
+}
+
+impl Write for LimitedOutputWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let amount_for_output = buf
+            .len()
+            .min(self.output_buffer.len() - self.amount_written);
+
+        self.output_buffer[self.amount_written..self.amount_written + amount_for_output]
+            .copy_from_slice(&buf[..amount_for_output]);
+        self.amount_written += amount_for_output;
+
+        if amount_for_output < buf.len() {
+            self.extra_queue.extend(&buf[amount_for_output..]);
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        // nothing to do since we don't buffer anything
+        Ok(())
+    }
+}
+
+const MAGIC_DECOMRESSION_CONTEXT: u32 = 87654321;
+const MAGIC_COMPRESSION_CONTEXT: u32 = 12345678;
+
+impl CompressionContext {
+    fn from_pointer(ptr: *mut std::ffi::c_void) -> &'static mut Self {
+        unsafe {
+            let context = ptr as *mut CompressionContext;
+            assert_eq!(
+                (*context).magic,
+                MAGIC_COMPRESSION_CONTEXT,
+                "invalid context passed in"
+            );
+            &mut *context
+        }
+    }
+
+    fn new(verify: bool, compression_level: i32, test_baseline: bool) -> Self {
+        CompressionContext {
+            magic: MAGIC_COMPRESSION_CONTEXT,
+            internal: ZstdCompressContext::new(
+                PreflateContainerProcessor::new(&PreflateContainerConfig {
+                    validate_compression: verify,
+                    max_chain_length: 1024, // lower max chain to avoid excessive CPU usage
+                    ..PreflateContainerConfig::default()
+                }),
+                compression_level,
+                test_baseline,
+            ),
+            output_extra: VecDeque::new(),
+        }
+    }
+}
+
+struct DecompressionContext {
+    magic: u32,
+    internal: ZstdDecompressContext<RecreateContainerProcessor>,
+    output_extra: VecDeque<u8>,
+}
+
+impl DecompressionContext {
+    fn from_pointer(ptr: *mut std::ffi::c_void) -> &'static mut Self {
+        unsafe {
+            let context = ptr as *mut DecompressionContext;
+            assert_eq!(
+                (*context).magic,
+                MAGIC_DECOMRESSION_CONTEXT,
+                "invalid context passed in"
+            );
+            &mut *context
+        }
+    }
+
+    fn new(capacity: usize) -> Self {
+        let internal = ZstdDecompressContext::new(RecreateContainerProcessor::new(capacity));
+
+        DecompressionContext {
+            magic: MAGIC_DECOMRESSION_CONTEXT,
+            internal,
+            output_extra: VecDeque::new(),
+        }
+    }
+}
+
+/// Processes input data, writing output to the output buffer and any extra to the output_extra queue.
+///
+/// This is necessary because in the unmanaged wrapper we cannot expand the buffer that was given to us,
+/// so we have to write as much as we can to the output buffer and then queue up any extra data for next time.
+///
+/// This avoids adding complexity to every ProcessBuffer implementation to handle the case where there is too
+/// much output to fit in the output buffer.
+fn process_limited_buffer(
+    process: &mut impl ProcessBuffer,
+    input: &[u8],
+    input_complete: bool,
+    output_buffer: &mut [u8],
+    output_extra: &mut VecDeque<u8>,
+) -> Result<(bool, usize), PreflateError> {
+    // first write any extra data we have pending from last time
+    let mut amount_written = 0;
+    while amount_written < output_buffer.len() && output_extra.len() > 0 {
+        amount_written += output_extra
+            .read(&mut output_buffer[amount_written..])
+            .unwrap();
+    }
+
+    // now call process buffer with the remaining space
+    let mut w = LimitedOutputWriter {
+        amount_written,
+        output_buffer,
+        extra_queue: output_extra,
+    };
+    let done = process.process_buffer(input, input_complete, &mut w)?;
+
+    Ok((done && w.extra_queue.len() == 0, w.amount_written))
+}
 
 /// Allocates new decompression context, must be freed with free_decompression_context
 #[unsafe(no_mangle)]
@@ -213,10 +334,7 @@ pub unsafe extern "C" fn create_decompression_context(
     capacity: u64,
 ) -> *mut std::ffi::c_void {
     match catch_unwind_result(|| {
-        let context = Box::new((
-            87654321u32,
-            DecompressionContext::new(RecreateContainerProcessor::new(capacity as usize)),
-        ));
+        let context = Box::new(DecompressionContext::new(capacity as usize));
         Ok(Box::into_raw(context) as *mut std::ffi::c_void)
     }) {
         Ok(context) => context,
@@ -231,8 +349,11 @@ pub unsafe extern "C" fn create_decompression_context(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn free_decompression_context(context: *mut std::ffi::c_void) {
     unsafe {
-        let x = Box::from_raw(context as *mut (u32, DecompressionContext));
-        assert_eq!(x.0, 87654321, "invalid context passed in");
+        let x = Box::from_raw(context as *mut DecompressionContext);
+        assert_eq!(
+            x.magic, MAGIC_DECOMRESSION_CONTEXT,
+            "invalid context passed in"
+        );
         // let Box destroy the object
     }
 }
@@ -255,9 +376,7 @@ pub unsafe extern "C" fn decompress_buffer(
 ) -> i32 {
     unsafe {
         match catch_unwind_result(|| {
-            let context = context as *mut (u32, DecompressionContext);
-            let (magic, context) = &mut *context;
-            assert_eq!(*magic, 87654321, "invalid context passed in");
+            let context = DecompressionContext::from_pointer(context);
 
             let input = if input_buffer == null() {
                 &[]
@@ -270,15 +389,15 @@ pub unsafe extern "C" fn decompress_buffer(
                 std::slice::from_raw_parts_mut(output_buffer, output_buffer_size as usize)
             };
 
-            let mut writer = Cursor::new(output);
-            let done = context.process_buffer(
+            let (done, buffer_written) = process_limited_buffer(
+                &mut context.internal,
                 input,
                 input_complete,
-                &mut writer,
-                output_buffer_size as usize,
+                output,
+                &mut context.output_extra,
             )?;
 
-            *result_size = writer.position().into();
+            *result_size = buffer_written as u64;
             Ok(done)
         }) {
             Ok(done) => done as i32,
@@ -317,6 +436,7 @@ fn extern_interface() {
     let original = read_file("samplezip.zip");
 
     let mut compressed = Vec::new();
+    let error_string = &mut [0u8; 1024];
 
     unsafe {
         let compression_context = create_compression_context(1);
@@ -335,10 +455,15 @@ fn extern_interface() {
                 compressed_chunk.as_mut_ptr(),
                 compressed_chunk.len() as u64,
                 (&mut result_size) as *mut u64,
-                std::ptr::null_mut(),
-                0,
+                error_string.as_mut_ptr(),
+                error_string.len() as u64,
             );
-            assert_eq!(retval, 0);
+            assert!(
+                retval == 0,
+                "expecting no error {} {:?}",
+                retval,
+                get_cstring(&error_string)
+            );
 
             compressed.extend_from_slice(&compressed_chunk[..(result_size as usize)]);
         });
@@ -354,10 +479,15 @@ fn extern_interface() {
                 compressed_chunk.as_mut_ptr(),
                 compressed_chunk.len() as u64,
                 (&mut result_size) as *mut u64,
-                std::ptr::null_mut(),
-                0,
+                error_string.as_mut_ptr(),
+                error_string.len() as u64,
             );
-            assert!(retval >= 0, "not expecting an error");
+            assert!(
+                retval >= 0,
+                "expecting no error {} {:?}",
+                retval,
+                get_cstring(&error_string)
+            );
 
             compressed.extend_from_slice(&compressed_chunk[..(result_size as usize)]);
 
@@ -409,10 +539,15 @@ fn extern_interface() {
                 decompressed_chunk.as_mut_ptr(),
                 decompressed_chunk.len() as u64,
                 (&mut result_size) as *mut u64,
-                std::ptr::null_mut(),
-                0,
+                error_string.as_mut_ptr(),
+                error_string.len() as u64,
             );
-            assert_eq!(retval, 0);
+            assert!(
+                retval == 0,
+                "expecting no error {} {:?}",
+                retval,
+                get_cstring(&error_string)
+            );
 
             recreated.extend_from_slice(&decompressed_chunk[..(result_size as usize)]);
         });
@@ -428,10 +563,16 @@ fn extern_interface() {
                 decompressed_chunk.as_mut_ptr(),
                 decompressed_chunk.len() as u64,
                 (&mut result_size) as *mut u64,
-                std::ptr::null_mut(),
-                0,
+                error_string.as_mut_ptr(),
+                error_string.len() as u64,
             );
-            assert!(retval >= 0, "not expecting an error");
+
+            assert!(
+                retval >= 0,
+                "expecting no error {} {:?}",
+                retval,
+                get_cstring(&error_string)
+            );
 
             recreated.extend_from_slice(&decompressed_chunk[..(result_size as usize)]);
 
@@ -469,7 +610,12 @@ fn test_error_translation() {
             error_string.len() as u64,
         );
 
-        assert!(retval == 0, "expecting no error");
+        assert!(
+            retval == 0,
+            "expecting no error {} {:?}",
+            retval,
+            get_cstring(&error_string)
+        );
 
         let retval = compress_buffer(
             compression_context,
@@ -485,9 +631,7 @@ fn test_error_translation() {
 
         assert_eq!(retval, -(ExitCode::InvalidParameter as i32));
 
-        let len = error_string.iter().position(|&x| x == 0).unwrap();
-
-        let error_string = std::ffi::CStr::from_bytes_with_nul(&error_string[0..len + 1]).unwrap();
+        let error_string = get_cstring(&error_string);
 
         assert!(
             error_string
@@ -496,4 +640,13 @@ fn test_error_translation() {
                 .starts_with("more data provided after input_complete signaled"),
         );
     }
+}
+
+/// helper to get a cstring from a fixed size array for testing (finds zero terminator)
+#[cfg(test)]
+fn get_cstring<'a, const N: usize>(error_string: &'a [u8; N]) -> &'a std::ffi::CStr {
+    let len = error_string.iter().position(|&x| x == 0).unwrap();
+
+    let error_string = std::ffi::CStr::from_bytes_with_nul(&error_string[0..len + 1]).unwrap();
+    error_string
 }

--- a/package/Preflate.Rust.nuspec
+++ b/package/Preflate.Rust.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Preflate.Rust</id>
-    <version>0.7.3.0</version>
+    <version>0.7.4.0</version>
     <title>PreflateRs Compression Rust binaries and libraries</title>
     <authors>kristofr</authors>
     <owners>kristofr</owners>

--- a/util/src/main.rs
+++ b/util/src/main.rs
@@ -112,7 +112,6 @@ fn main() {
             &mut Cursor::new(&original),
             &mut preflate_compressed,
             usize::MAX,
-            usize::MAX,
         ) {
             println!("Skipping due to error: {:?}", e);
             continue;
@@ -148,7 +147,6 @@ fn main() {
             if let Err(e) = decomp.copy_to_end_size(
                 &mut Cursor::new(&preflate_compressed),
                 &mut recreated,
-                usize::MAX,
                 usize::MAX,
             ) {
                 println!("Verification error: {:?}", e);


### PR DESCRIPTION
Instead of having every implementation of ProcessBuffer have to worry about emitting too many bytes, make one implementation that is used in the DLL to handle the case where more output is generated that can be consumed by the DLL fixed buffer version. 

This also means that ProcessBuffer doesn't need to return whether it is complete or not anymore or take a parameter with the maximum buffer size.

This allows all the implementations not to have to worry about this corner case and only implement it once.

Unrelated changes: add missing version updates from previous checkin and add task.json to build the whole workspace by default in VSCode.